### PR TITLE
fix wrong patch

### DIFF
--- a/xpe_default.xml
+++ b/xpe_default.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <!-- Github remote -->
-  <remote  name="github"
-           fetch="https://github.com/" />
+    <!-- Github remote -->
+    <remote  name="github"
+             fetch="https://github.com/" />
 
     <!-- The XPerience Project Repos -->
 
@@ -24,7 +24,6 @@
       <linkfile src="target" dest="build/target" />
       <linkfile src="tools" dest="build/tools" />
     </project>
-
     <project path="build/soong" name="TheXPerienceProject/android_build_soong" groups="pdk,tradefed" remote="xpe" >
       <linkfile src="root.bp" dest="Android.bp" />
       <linkfile src="bootstrap.bash" dest="bootstrap.bash" />
@@ -33,39 +32,38 @@
     <!--device-->
     <project path="device/qcom/common" name="TheXPerienceProject/android_device_qcom_common" remote="xpe" />
 
-
     <!-- External -->
-	<project path="external/e2fsprogs" name="TheXPerienceProject/android_external_e2fsprogs" groups="pdk" remote="xpe" />
-	<project path="external/selinux" name="TheXPerienceProject/android_external_selinux" groups="pdk" remote="xpe" />
+    <project path="external/e2fsprogs" name="TheXPerienceProject/android_external_e2fsprogs" groups="pdk" remote="xpe" />
+    <project path="external/selinux" name="TheXPerienceProject/android_external_selinux" groups="pdk" remote="xpe" />
     <project path="external/tinycompress" name="TheXPerienceProject/android_external_tinycompress" groups="pdk"  remote="xpe" />
     <project path="external/perfetto" name="TheXPerienceProject/android_external_perfetto" groups="pdk" remote="xpe" />
 
     <!--Frameworks -->
-	<project path="frameworks/base" name="TheXPerienceProject/android_frameworks_base" groups="pdk-cw-fs,pdk-fs" remote="xpe" />
+    <project path="frameworks/base" name="TheXPerienceProject/android_frameworks_base" groups="pdk-cw-fs,pdk-fs" remote="xpe" />
     <project path="frameworks/av" name="TheXPerienceProject/android_frameworks_av" groups="pdk-cw-fs,pdk-fs" remote="xpe"  />
     <project path="frameworks/native" name="TheXPerienceProject/android_frameworks_native" groups="pdk" remote="xpe"  />
     <project path="frameworks/opt/net/wifi" name="TheXPerienceProject/android_frameworks_opt_net_wifi" groups="pdk" remote="xpe"  />
 
     <!-- Hardware -->
-    <project path="hardware/libhardware"              name="TheXPerienceProject/android_hardware_libhardware"  groups="pdk" remote="xpe" />
-    <project path="hardware/libhardware_legacy"       name="TheXPerienceProject/android_hardware_libhardware_legacy"  groups="pdk" remote="xpe" />
-    <project path="hardware/qcom/keymaster"           name="TheXPerienceProject/android_hardware_qcom_keymaster" groups="qcom,qcom_keymaster,pdk-qcom" remote="xpe" />
-    <project path="hardware/qcom/audio"               name="TheXPerienceProject/android_hardware_qcom_audio"  groups="pdk-qcom,qcom,qcom_audio" remote="xpe" />
-    <project path="hardware/qcom/audio-caf/msm8952"   name="TheXPerienceProject/android_hardware_qcom_audio" groups="pdk,qcom,qcom_audio" revision="xpe-13.0-caf-8974" remote="xpe" />
-    <project path="hardware/qcom/audio-caf/msm8974"   name="TheXPerienceProject/android_hardware_qcom_audio" groups="pdk,qcom,qcom_audio" revision="xpe-13.0-caf-8974" remote="xpe" />
-    <project path="hardware/qcom/audio-caf/msm8996"   name="TheXPerienceProject/android_hardware_qcom_audio" groups="pdk,qcom,qcom_audio" revision="xpe-13.0-caf-8996" remote="xpe" />
-    <project path="hardware/qcom/display"             name="TheXPerienceProject/android_hardware_qcom_display"  groups="pdk-qcom,qcom,qcom_display" remote="xpe" />
+    <project path="hardware/libhardware" name="TheXPerienceProject/android_hardware_libhardware" groups="pdk" remote="xpe" />
+    <project path="hardware/libhardware_legacy" name="TheXPerienceProject/android_hardware_libhardware_legacy" groups="pdk" remote="xpe" />
+    <project path="hardware/qcom/keymaster" name="TheXPerienceProject/android_hardware_qcom_keymaster" groups="qcom,qcom_keymaster,pdk-qcom" remote="xpe" />
+    <project path="hardware/qcom/audio" name="TheXPerienceProject/android_hardware_qcom_audio" groups="pdk-qcom,qcom,qcom_audio" remote="xpe" />
+    <project path="hardware/qcom/audio-caf/msm8952" name="TheXPerienceProject/android_hardware_qcom_audio" groups="pdk,qcom,qcom_audio" revision="xpe-13.0-caf-8974" remote="xpe" />
+    <project path="hardware/qcom/audio-caf/msm8974" name="TheXPerienceProject/android_hardware_qcom_audio" groups="pdk,qcom,qcom_audio" revision="xpe-13.0-caf-8974" remote="xpe" />
+    <project path="hardware/qcom/audio-caf/msm8996" name="TheXPerienceProject/android_hardware_qcom_audio" groups="pdk,qcom,qcom_audio" revision="xpe-13.0-caf-8996" remote="xpe" />
+    <project path="hardware/qcom/display" name="TheXPerienceProject/android_hardware_qcom_display" groups="pdk-qcom,qcom,qcom_display" remote="xpe" />
     <project path="hardware/qcom/display-caf/msm8952" name="TheXPerienceProject/android_hardware_qcom_display" groups="pdk,qcom,qcom_display" revision="xpe-13.0-caf-8974" remote="xpe" />
     <project path="hardware/qcom/display-caf/msm8974" name="TheXPerienceProject/android_hardware_qcom_display" groups="pdk,qcom,qcom_display" revision="xpe-13.0-caf-8974" remote="xpe" />
     <project path="hardware/qcom/display-caf/msm8996" name="TheXPerienceProject/android_hardware_qcom_display" groups="pdk,qcom,qcom_display" revision="xpe-13.0-caf-8996" remote="xpe" />
-    <project path="hardware/qcom/media"               name="TheXPerienceProject/android_hardware_qcom_media"  groups="pdk-qcom,qcom,qcom_media" remote="xpe" />
-    <project path="hardware/qcom/media-caf/msm8952"   name="TheXPerienceProject/android_hardware_qcom_media" groups="pdk,qcom,qcom_media" revision="xpe-13.0-caf-8974" remote="xpe" />
-    <project path="hardware/qcom/media-caf/msm8974"   name="TheXPerienceProject/android_hardware_qcom_media" groups="pdk,qcom,qcom_media" revision="xpe-13.0-caf-8974" remote="xpe" />
-    <project path="hardware/qcom/media-caf/msm8996"   name="TheXPerienceProject/android_hardware_qcom_media" groups="pdk,qcom,qcom_media" revision="xpe-13.0-caf-8996" remote="xpe" />
-    <project path="hardware/qcom/wlan"                name="TheXPerienceProject/android_hardware_qcom_wlan" groups="qcom_wlan,pdk-qcom" revision="xpe-13.0"  remote="xpe" />
-    <project path="hardware/qcom/wlan-caf"            name="TheXPerienceProject/android_hardware_qcom_wlan" groups="qcom_wlan,pdk-qcom" revision="xpe-13.0-caf"  remote="xpe" />
-    <project path="hardware/qcom/ril"                 name="TheXPerienceProject/android_hardware_ril" groups="pdk" revision="xpe-13.0"  remote="xpe" />
-    <project path="hardware/qcom/ril-caf"             name="TheXPerienceProject/android_hardware_ril" groups="pdk" revision="xpe-13.0-caf"  remote="xpe" />
+    <project path="hardware/qcom/media" name="TheXPerienceProject/android_hardware_qcom_media" groups="pdk-qcom,qcom,qcom_media" remote="xpe" />
+    <project path="hardware/qcom/media-caf/msm8952" name="TheXPerienceProject/android_hardware_qcom_media" groups="pdk,qcom,qcom_media" revision="xpe-13.0-caf-8974" remote="xpe" />
+    <project path="hardware/qcom/media-caf/msm8974" name="TheXPerienceProject/android_hardware_qcom_media" groups="pdk,qcom,qcom_media" revision="xpe-13.0-caf-8974" remote="xpe" />
+    <project path="hardware/qcom/media-caf/msm8996" name="TheXPerienceProject/android_hardware_qcom_media" groups="pdk,qcom,qcom_media" revision="xpe-13.0-caf-8996" remote="xpe" />
+    <project path="hardware/qcom/wlan" name="TheXPerienceProject/android_hardware_qcom_wlan" groups="qcom_wlan,pdk-qcom" revision="xpe-13.0" remote="xpe" />
+    <project path="hardware/qcom/wlan-caf" name="TheXPerienceProject/android_hardware_qcom_wlan" groups="qcom_wlan,pdk-qcom" revision="xpe-13.0-caf" remote="xpe" />
+    <project path="hardware/ril" name="TheXPerienceProject/android_hardware_ril" groups="pdk" revision="xpe-13.0" remote="xpe" />
+    <project path="hardware/ril-caf" name="TheXPerienceProject/android_hardware_ril" groups="pdk" revision="xpe-13.0-caf" remote="xpe" />
 
     <!-- Packages -->
     <project path="packages/apps/Settings" name="TheXPerienceProject/android_packages_apps_settings" groups="pdk-fs" remote="xpe" />
@@ -74,7 +72,6 @@
 
     <!-- Prebuilts -->
     <project path="prebuilts/build-tools" name="TheXPerienceProject/android_prebuilts_build-tools" groups="pdk" clone-depth="1" remote="xpe" />
-
 
     <!-- System -->
     <project path="system/bt" name="TheXPerienceProject/android_system_bt" groups="pdk" remote="xpe" />


### PR DESCRIPTION
* ninja: error: '/root/xpe/out/target/common/obj/JAVA_LIBRARIES/sap-api-java-static_intermediates/classes-header.jar', needed by '/root/xpe/out/target/common/obj/APPS/Bluetooth_intermediates/classes-full-debug.jar', missing and no known rule to make it